### PR TITLE
Fixed messageId binding

### DIFF
--- a/frontend/src/pages/Meme/index.tsx
+++ b/frontend/src/pages/Meme/index.tsx
@@ -222,7 +222,7 @@ export const MemePage = () => {
           <ChannelBlock
             isAdmin={isAdmin}
             username={request.data.channel}
-            id={request.data.message}
+            id={request.data.messageId}
             {...stylex.props(s.sourceBlock)}
             onClickImages={onClickChannelImages}
             onClickEraser={onClickDeleteChannelMemes}

--- a/frontend/src/types/IMeme.ts
+++ b/frontend/src/types/IMeme.ts
@@ -1,7 +1,7 @@
 export type IMeme = {
   id: string
   channel: string
-  message: string
+  messageId: string
   fileName: string
   text: Record<'eng', string>
 }


### PR DESCRIPTION
Thanks for this project, it's amazing!

It seems that link to an individual message is meant to be working, but it doesn't work. I noticed that `messageId` field comes from the backend, but on the Frontend it seems that it's being taken as `message`. I didn't manage to spin the whole stack up and test the change, but I hope it doesn't break anything